### PR TITLE
Create pull_request_template.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+### What (if any) features are you implementing?
+-
+### What (if anything) did you refactor?
+-
+### Were there any issues that arose?
+-
+### Is there anything that you need from your teammate?
+-
+### Refactor checklist
+- [] Check variable and parameter names: are they descriptive and unique?
+- [] Is the code DRY? SRP?
+- [] Is it easy for others to read your code? (explanatory comments needed?)
+- [] Is the syntax consistent? (e.g. use of semicolons, blank lines)
+- [] Are commit messages formatted correctly?


### PR DESCRIPTION
Note to self: by trying to follow the Turing directions, I set up my repo incorrectly. I trusted them over the regular github workflow and my own gut. Now my base branch is not called main. It's called test/repo-connection which I assume is a default that github uses when you don't property set up and connect your main branch. This is frustrating but I think it will be ok if I change the upstream location for my local main to the 'repo-connection'